### PR TITLE
Code tidying

### DIFF
--- a/04_analysis/05_Expected_Value_of_Sample_Information_Bespoke_Example.R
+++ b/04_analysis/05_Expected_Value_of_Sample_Information_Bespoke_Example.R
@@ -53,7 +53,7 @@ evsi_utility <- evsi(outputs = chemotherapy_output,
                      pars = c("u_hospital"),
                      n = seq(50, 1000, by = 200),
                      method = "gam",
-                     datagen_fn = utility_datagen_fn_rb)
+                     datagen_fn = utility_datagen_fn_agg)
 
 ## Moment Matching Method
 # Analysis function based on JAGS


### PR DESCRIPTION
* Imposed a maximum of 75 columns for the code, which we need for the book margins

* Merged the MM/IS utility functions and implemented the aggregate one as a wrapper around the individual one

* Changed JAGS code to text string.  I don't like that feature of R2WinBUGS/R2OpenBUGS which pretends that JAGS code is R code - this makes it harder for people to learn JAGS syntax.

* Sourced the `betaPar` function rather than passing it as an argument

* `nsim` argument to `evsi()` and `evppi()` is a shortcut to using a smaller PA sample size to save computation

* Added a `"pars_datagen"` argument to the first importance sampling command.  [ I need to improve the doc for this. likewise for the argument formats for the likelihood function ]

* `"default"` is misleading - there is no default study design in `evsi()` - "built-in" is clearer.

* Various other edits for tidiness
